### PR TITLE
Accuracy fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ export const App: React.FC = () => {
                     component={MatchList}
                   />
                   <Route
-                    path="/matches/:matchId/:map"
+                    path="/matches/:matchId"
                     component={MatchDetails}
                   />
                   <Route exact path="/players" component={PlayerList} />

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -248,6 +248,33 @@ export interface IStatsResponse {
   statsall: IPlayerStatsDictionary[];
   match_id: string;
   type: string;
+  match_summary: iMatchSummary;
+}
+
+export interface iMatchSummary {
+  duration: number;
+  duration_nice: string;
+  finish_human: string;
+  games: number;
+  results: iGameResultsObject;
+}
+
+export interface iGameResultsObject {
+  [match_id: string]: iGameResult;
+}
+
+export interface iGameResult {
+  map: string;
+  winner: string;
+  winnerAB: string;
+  round1: {
+    duration: number;
+    duration_nice: string;
+  };
+  round2: {
+    duration: number;
+    duration_nice: string;
+  }
 }
 
 export interface ITeamOverviewData {

--- a/src/components/MatchStats/MatchStatsPlayerTable.tsx
+++ b/src/components/MatchStats/MatchStatsPlayerTable.tsx
@@ -26,7 +26,7 @@ export const MatchStatsPlayerTable: React.FC<{
 
   const fetchMatchDetails = (e: MouseEvent) => {
     const matchId = e.currentTarget.getAttribute("data-match-id");
-    history.push(`/matches/${matchId}/unknown`);
+    history.push(`/matches/${matchId}`);
   };
 
   return (

--- a/src/components/PlayerStats/PlayerStats.tsx
+++ b/src/components/PlayerStats/PlayerStats.tsx
@@ -44,6 +44,12 @@ const PlayerStats: React.FC<{
       )}%`
     : "N/A";
 
+  const accuracy = aggStatsRegion["hits"]
+    ? `${((aggStatsRegion["hits"] / aggStatsRegion["shots"]) * 100).toFixed(
+        2
+      )}%`
+    : "N/A";
+
   const objectivePerGame = aggStatsRegion["obj_captured"]
     ? `${(
         (aggStatsRegion["obj_captured"] / aggStatsRegion["games"]) *
@@ -85,8 +91,8 @@ const PlayerStats: React.FC<{
             <StatLabel>Accuracy</StatLabel>
             <StatNumber>
               {(aggStatsRegion &&
-                aggStatsRegion["accuracy"] &&
-                `${aggStatsRegion["accuracy"] / 100}%`) ||
+                accuracy &&
+                `${accuracy}`) ||
                 "N/A"}
             </StatNumber>
           </Stat>

--- a/src/pages/matches/MatchDetails/MatchDetails.tsx
+++ b/src/pages/matches/MatchDetails/MatchDetails.tsx
@@ -10,11 +10,16 @@ import { PageTitle } from "../../../components/PageTitle";
 import { MatchStats } from "../../../components/MatchStats";
 
 export const MatchDetails: React.FC = () => {
-  const { matchId, map } = useParams<{ matchId: string; map: string }>();
+  const { matchId } = useParams<{ matchId: string }>();
   const { data, isLoading } = useQuery<IStatsResponse>(
     ["match-stats", matchId],
     () => StatsApi.Matches.MatchStats(matchId)
   );
+  
+  let map = "unknown";
+  if (data && "match_summary" in data) {
+    map = data?.match_summary.results[Object.keys(data.match_summary.results)[0]].map;
+  }
 
   const actualData = useMemo(() => {
     if (!data) {

--- a/src/pages/matches/MatchList/MatchListContent.tsx
+++ b/src/pages/matches/MatchList/MatchListContent.tsx
@@ -47,7 +47,7 @@ export const MatchListContent: React.FC<{ data: IMatch[] }> = ({ data }) => {
                 <Td>
                   <Link
                     as={reactLink}
-                    to={`/matches/${match.match_id}/${match.map}`}
+                    to={`/matches/${match.match_id}`}
                   >
                     {match.map}
                   </Link>
@@ -55,7 +55,7 @@ export const MatchListContent: React.FC<{ data: IMatch[] }> = ({ data }) => {
                 <Td>
                   <Link
                     as={reactLink}
-                    to={`/matches/${match.match_id}/${match.map}`}
+                    to={`/matches/${match.match_id}`}
                   >
                     {match.server_name}
                   </Link>


### PR DESCRIPTION
accuracy, killpeak, effec* from player stats are useless as they are pre-calced values from the game and aggregation messes them up. Replaced accuracy = hits/shots 
Will fix killpeak later